### PR TITLE
Load/Unload process improvements and convar query fix

### DIFF
--- a/Amalgam/src/BytePatches/BytePatches.cpp
+++ b/Amalgam/src/BytePatches/BytePatches.cpp
@@ -20,16 +20,16 @@ void BytePatch::Write(std::vector<byte>& bytes)
 	VirtualProtect(m_pAddress, m_iSize, flNewProtect, &flOldProtect);
 }
 
-void BytePatch::Initialize()
+bool BytePatch::Initialize()
 {
 	if (m_bIsPatched)
-		return;
+		return true;
 
 	m_pAddress = LPVOID(U::Memory.FindSignature(m_sModule, m_sSignature));
 	if (!m_pAddress)
 	{
 		OutputDebugStringA(std::format("BytePatch::Initialize() failed to initialize:\n  {}\n  {}\n", m_sModule, m_sSignature).c_str());
-		return;
+		return false;
 	}
 
 	m_pAddress = LPVOID(uintptr_t(m_pAddress) + m_iOffset);
@@ -40,7 +40,7 @@ void BytePatch::Initialize()
 	VirtualProtect(m_pAddress, m_iSize, flNewProtect, &flOldProtect);
 
 	Write(m_vPatch);
-	m_bIsPatched = true;
+	return m_bIsPatched = true;
 }
 
 void BytePatch::Unload()
@@ -54,15 +54,19 @@ void BytePatch::Unload()
 
 
 
-void CBytePatches::Initialize()
+bool CBytePatches::Initialize()
 {
 	m_vPatches = {
 		BytePatch("engine.dll", "0F 82 ? ? ? ? 4A 63 84 2F", 0x0, "90 90 90 90 90 90"), // skybox fix
 		BytePatch("server.dll", "75 ? 44 38 A7 ? ? ? ? 75 ? 41 3B DD", 0x0, "EB") // listen server speedhack
 	};
 
+	bool bFail{false};
 	for (auto& patch : m_vPatches)
-		patch.Initialize();
+		if (!patch.Initialize())
+			bFail = true;
+
+	return !bFail;
 }
 
 void CBytePatches::Unload()

--- a/Amalgam/src/BytePatches/BytePatches.h
+++ b/Amalgam/src/BytePatches/BytePatches.h
@@ -17,14 +17,14 @@ class BytePatch
 public:
 	BytePatch(const char* sModule, const char* sSignature, int iOffset, const char* sPatch);
 
-	void Initialize();
+	bool Initialize();
 	void Unload();
 };
 
 class CBytePatches
 {
 public:
-	void Initialize();
+	bool Initialize();
 	void Unload();
 
 	std::vector<BytePatch> m_vPatches = {};

--- a/Amalgam/src/Core/Core.cpp
+++ b/Amalgam/src/Core/Core.cpp
@@ -19,31 +19,45 @@ void CCore::Load()
 	}
 	Sleep(500);
 
+	
+	// What is this here for??
 	// Check the DirectX version
-	if (bUnload)
-		return;
+	/*if (bUnload)
+		return;*/
 
-	SDK::GetTeamFortressWindow();
-	U::Signatures.Initialize();
-	U::Interfaces.Initialize();
-	U::ConVars.Initialize();
-	U::Hooks.Initialize();
-	U::BytePatches.Initialize();
-	H::Events.Initialize();
-	F::Materials.LoadMaterials();
-	F::Commands.Initialize();
+	if(!(bUnload = bEarly = !SDK::GetTeamFortressWindow()))
+	{
+		if (!(bUnload = bEarly = !U::Signatures.Initialize()))
+		{
+			if (!(bUnload = bEarly = !U::Interfaces.Initialize()))
+			{
+				U::ConVars.Initialize();
+				if (!(bUnload = !U::Hooks.Initialize()))
+				{
+					if (!(bUnload = !U::BytePatches.Initialize()))
+					{
+						if (!(bUnload = !H::Events.Initialize()))
+						{
+							F::Materials.LoadMaterials();
+							F::Commands.Initialize();
 
-	F::Configs.LoadConfig(F::Configs.sCurrentConfig, false);
-	F::Menu.ConfigLoaded = true;
+							F::Configs.LoadConfig(F::Configs.sCurrentConfig, false);
+							F::Menu.ConfigLoaded = true;
 
-	SDK::Output("Amalgam", "Loaded", { 175, 150, 255, 255 }, true, false, false, true);
+							SDK::Output("Amalgam", "Loaded", { 175, 150, 255, 255 }, true, false, false, true);
+						}
+					}
+				}
+			}
+		}
+	}
 }
 
 void CCore::Loop()
 {
 	while (true)
 	{
-		bool bShouldUnload = U::KeyHandler.Down(VK_F11) && SDK::IsGameWindowInFocus() || bUnload;
+		bool bShouldUnload = bUnload || U::KeyHandler.Down(VK_F11) && SDK::IsGameWindowInFocus();
 		if (bShouldUnload)
 			break;
 
@@ -53,9 +67,10 @@ void CCore::Loop()
 
 void CCore::Unload()
 {
-	if (bEarly)
+	if (bEarly) 
 	{
-		SDK::Output("Amalgam", "Cancelled", { 175, 150, 255, 255 }, true, false, false, true);
+		// Cant use console here since I::CVar is not initialized yet
+		SDK::Output("Amalgam", "Cancelled", { 175, 150, 255, 255 }, false, false, false, true);
 		return;
 	}
 

--- a/Amalgam/src/DllMain.cpp
+++ b/Amalgam/src/DllMain.cpp
@@ -6,6 +6,7 @@ DWORD WINAPI MainThread(LPVOID lpParam)
 {
 	U::Core.Load();
 	U::Core.Loop();
+	CrashLog::Unload(); // 0xC0000409
 	U::Core.Unload();
 
 	FreeLibraryAndExitThread(static_cast<HMODULE>(lpParam), EXIT_SUCCESS);

--- a/Amalgam/src/Hooks/CBaseAnimating_SetupBones.cpp
+++ b/Amalgam/src/Hooks/CBaseAnimating_SetupBones.cpp
@@ -5,7 +5,7 @@ MAKE_SIGNATURE(CBaseAnimating_SetupBones, "client.dll", "48 8B C4 44 89 40 ? 48 
 MAKE_HOOK(CBaseAnimating_SetupBones, S::CBaseAnimating_SetupBones(), bool,
 	void* rcx, matrix3x4* pBoneToWorldOut, int nMaxBones, int boneMask, float currentTime)
 {
-	if (Vars::Misc::Game::SetupBonesOptimization.Value && !H::Entities.IsSettingUpBones())
+	if (!G::Unload && Vars::Misc::Game::SetupBonesOptimization.Value && !H::Entities.IsSettingUpBones())
 	{
 		auto pBaseEntity = reinterpret_cast<CBaseEntity*>(uintptr_t(rcx) - 8);
 		if (pBaseEntity)

--- a/Amalgam/src/Hooks/CBaseEntity_FireBullets.cpp
+++ b/Amalgam/src/Hooks/CBaseEntity_FireBullets.cpp
@@ -9,7 +9,7 @@ MAKE_HOOK(CBaseEntity_FireBullets, S::CBaseEntity_FireBullets(), void,
 {
 	auto pLocal = H::Entities.GetLocal();
 	auto pPlayer = reinterpret_cast<CBaseEntity*>(rcx);
-	if (!pLocal || pPlayer != pLocal)
+	if (!pLocal || pPlayer != pLocal || G::Unload)
 		return CALL_ORIGINAL(rcx, pWeapon, info, bDoEffects, nDamageType, nCustomDamageType);
 
 	const Vec3 vStart = info.m_vecSrc;

--- a/Amalgam/src/Hooks/CBaseEntity_SetAbsVelocity.cpp
+++ b/Amalgam/src/Hooks/CBaseEntity_SetAbsVelocity.cpp
@@ -60,7 +60,7 @@ MAKE_HOOK(CBaseEntity_SetAbsVelocity, S::CBaseEntity_SetAbsVelocity(), void,
 	static const auto dwDesired = S::CBasePlayer_PostDataUpdate_SetAbsVelocity_Call();
 	const auto dwRetAddr = uintptr_t(_ReturnAddress());
 
-	if (dwRetAddr != dwDesired)
+	if (dwRetAddr != dwDesired || G::Unload)
 		return CALL_ORIGINAL(rcx, vecAbsVelocity);
 	
 	const auto pPlayer = reinterpret_cast<CTFPlayer*>(rcx);

--- a/Amalgam/src/Hooks/CBasePlayer_CalcViewModelView.cpp
+++ b/Amalgam/src/Hooks/CBasePlayer_CalcViewModelView.cpp
@@ -67,7 +67,5 @@ MAKE_HOOK(CBasePlayer_CalcViewModelView, S::CBasePlayer_CalcViewModelView(), voi
 MAKE_HOOK(ClientModeTFNormal_GetViewModelFOV, U::Memory.GetVFunc(I::ClientModeShared, 32), float,
 	/*void* rcx*/)
 {
-	if (float flFOV = Vars::Visuals::Viewmodel::FieldOfView.Value)
-		return flFOV;
-	return CALL_ORIGINAL(/*rcx*/);
+	return Vars::Visuals::Viewmodel::FieldOfView.Value ? Vars::Visuals::Viewmodel::FieldOfView.Value : CALL_ORIGINAL(/*rcx*/);
 }

--- a/Amalgam/src/Hooks/CClientModeShared_CreateMove.cpp
+++ b/Amalgam/src/Hooks/CClientModeShared_CreateMove.cpp
@@ -21,7 +21,7 @@ MAKE_HOOK(CClientModeShared_CreateMove, U::Memory.GetVFunc(I::ClientModeShared, 
 	G::Buttons = pCmd ? pCmd->buttons : G::Buttons;
 
 	const bool bReturn = CALL_ORIGINAL(rcx, flInputSampleTime, pCmd);
-	if (!pCmd || !pCmd->command_number)
+	if (!pCmd || !pCmd->command_number || G::Unload)
 		return bReturn;
 
 	bool* pSendPacket = reinterpret_cast<bool*>(uintptr_t(_AddressOfReturnAddress()) + 0x128);

--- a/Amalgam/src/Hooks/CClientModeShared_DoPostScreenSpaceEffects.cpp
+++ b/Amalgam/src/Hooks/CClientModeShared_DoPostScreenSpaceEffects.cpp
@@ -10,7 +10,7 @@ MAKE_HOOK(CClientModeShared_DoPostScreenSpaceEffects, U::Memory.GetVFunc(I::Clie
 {
 	F::Chams.mEntities.clear();
 
-	if (I::EngineVGui->IsGameUIVisible() || Vars::Visuals::UI::CleanScreenshots.Value && I::EngineClient->IsTakingScreenshot())
+	if (I::EngineVGui->IsGameUIVisible() || Vars::Visuals::UI::CleanScreenshots.Value && I::EngineClient->IsTakingScreenshot() || G::Unload)
 		return CALL_ORIGINAL(rcx, pSetup);
 
 	auto pLocal = H::Entities.GetLocal();

--- a/Amalgam/src/Hooks/CL_ProcessPacketEntities.cpp
+++ b/Amalgam/src/Hooks/CL_ProcessPacketEntities.cpp
@@ -30,7 +30,7 @@ struct CriticalStorage_t
 MAKE_HOOK(CL_ProcessPacketEntities, S::CL_ProcessPacketEntities(), bool,
 	SVC_PacketEntities* entmsg)
 {
-	if (entmsg->m_bIsDelta) // we won't need to restore
+	if (entmsg->m_bIsDelta || G::Unload) // we won't need to restore
 		return CALL_ORIGINAL(entmsg);
 
 	CTFPlayer* pLocal = I::ClientEntityList->GetClientEntity(I::EngineClient->GetLocalPlayer())->As<CTFPlayer>();

--- a/Amalgam/src/Hooks/CNetChannel_SendDatagram.cpp
+++ b/Amalgam/src/Hooks/CNetChannel_SendDatagram.cpp
@@ -7,7 +7,7 @@ MAKE_SIGNATURE(CNetChannel_SendDatagram, "engine.dll", "40 55 57 41 56 48 8D AC 
 MAKE_HOOK(CNetChannel_SendDatagram, S::CNetChannel_SendDatagram(), int,
 	CNetChannel* pNetChan, bf_write* datagram)
 {
-	if (datagram)
+	if (datagram || G::Unload)
 		return CALL_ORIGINAL(pNetChan, datagram);
 
 	F::Backtrack.AdjustPing(pNetChan);

--- a/Amalgam/src/Hooks/CTFWeaponBase_CalcIsAttackCritical.cpp
+++ b/Amalgam/src/Hooks/CTFWeaponBase_CalcIsAttackCritical.cpp
@@ -8,7 +8,7 @@ MAKE_HOOK(CTFWeaponBase_CalcIsAttackCritical, S::CTFWeaponBase_CalcIsAttackCriti
 {
 	auto pLocal = H::Entities.GetLocal();
 	auto pWeapon = H::Entities.GetWeapon();
-	if (!pLocal || !pWeapon || pWeapon != rcx)
+	if (!pLocal || !pWeapon || pWeapon != rcx || G::Unload)
 		CALL_ORIGINAL(rcx);
 
 	if (!F::CritHack.CalcIsAttackCriticalHandler(pLocal, pWeapon))

--- a/Amalgam/src/Hooks/ClientModeTFNormal_BIsFriendOrPartyMember.cpp
+++ b/Amalgam/src/Hooks/ClientModeTFNormal_BIsFriendOrPartyMember.cpp
@@ -7,8 +7,5 @@ MAKE_HOOK(ClientModeTFNormal_BIsFriendOrPartyMember, S::ClientModeTFNormal_BIsFr
 {
 	static const auto dwDesired = S::CHudInspectPanel_UserCmd_InspectTarget_BIsFriendOrPartyMember_Call();
 	const auto dwRetAddr = uintptr_t(_ReturnAddress());
-
-	if (dwRetAddr == dwDesired && Vars::Misc::MannVsMachine::AllowInspect.Value)
-		return true;
-	return CALL_ORIGINAL(rcx, pEntity);
+	return dwRetAddr == dwDesired && Vars::Misc::MannVsMachine::AllowInspect.Value ? true : CALL_ORIGINAL(rcx, pEntity);
 }

--- a/Amalgam/src/Hooks/FX_FireBullets.cpp
+++ b/Amalgam/src/Hooks/FX_FireBullets.cpp
@@ -12,14 +12,16 @@ MAKE_HOOK(FX_FireBullets, S::FX_FireBullets(), void,
 {
 	static const auto dwDesired = S::CTFWeaponBaseGun_FireBullet_FireBullets_Call();
 	const auto dwRetAddr = uintptr_t(_ReturnAddress());
-
-	if (iPlayer != I::EngineClient->GetLocalPlayer())
+	if (!G::Unload)
 	{
-		F::Backtrack.ReportShot(iPlayer);
-		F::Resolver.FXFireBullet(iPlayer, vecAngles);
+		if (iPlayer != I::EngineClient->GetLocalPlayer())
+		{
+			F::Backtrack.ReportShot(iPlayer);
+			F::Resolver.FXFireBullet(iPlayer, vecAngles);
+		}
+		else if (Vars::Aimbot::General::NoSpread.Value && dwRetAddr == dwDesired)
+			iSeed = F::NoSpreadHitscan.m_iSeed;
 	}
-	else if (Vars::Aimbot::General::NoSpread.Value && dwRetAddr == dwDesired)
-		iSeed = F::NoSpreadHitscan.m_iSeed;
 
 	return CALL_ORIGINAL(pWpn, iPlayer, vecOrigin, vecAngles, iWeapon, iMode, iSeed, flSpread, flDamage, bCritical);
 }

--- a/Amalgam/src/Hooks/IBaseClientDLL_FrameStageNotify.cpp
+++ b/Amalgam/src/Hooks/IBaseClientDLL_FrameStageNotify.cpp
@@ -15,6 +15,9 @@
 MAKE_HOOK(IBaseClientDLL_FrameStageNotify, U::Memory.GetVFunc(I::BaseClientDLL, 35), void,
 	void* rcx, ClientFrameStage_t curStage)
 {
+	if (G::Unload)
+		return CALL_ORIGINAL(rcx, curStage);
+
 	switch (curStage)
 	{
 	case FRAME_RENDER_START:
@@ -94,8 +97,7 @@ MAKE_HOOK(IBaseClientDLL_FrameStageNotify, U::Memory.GetVFunc(I::BaseClientDLL, 
 	}
 	case FRAME_RENDER_START:
 	{
-		if (!G::Unload)
-			F::Visuals.Modulate();
+		F::Visuals.Modulate();
 	}
 	}
 }

--- a/Amalgam/src/Hooks/IEngineVGui_Paint.cpp
+++ b/Amalgam/src/Hooks/IEngineVGui_Paint.cpp
@@ -57,6 +57,6 @@ MAKE_HOOK(IEngineVGui_Paint, U::Memory.GetVFunc(I::EngineVGui, 14), void,
 {
 	CALL_ORIGINAL(rcx, iMode);
 
-	if (iMode & PAINT_UIPANELS)
+	if (iMode & PAINT_UIPANELS && !G::Unload)
 		Paint();
 }

--- a/Amalgam/src/Hooks/IVEngineClient_ClientCmd_Unrestricted.cpp
+++ b/Amalgam/src/Hooks/IVEngineClient_ClientCmd_Unrestricted.cpp
@@ -24,19 +24,22 @@ private:
 MAKE_HOOK(IVEngineClient_ClientCmd_Unrestricted, U::Memory.GetVFunc(I::EngineClient, 106), void,
 	void* rcx, const char* szCmdString)
 {
-	std::string sCmdString = szCmdString;
-	std::transform(sCmdString.begin(), sCmdString.end(), sCmdString.begin(), ::tolower);
-
-	std::deque<std::string> vArgs;
-	boost::split(vArgs, sCmdString, split_q());
-
-	if (!vArgs.empty())
+	if (!G::Unload)
 	{
-		std::string sCommand = vArgs.front();
-		vArgs.pop_front();
+		std::string sCmdString = szCmdString;
+		std::transform(sCmdString.begin(), sCmdString.end(), sCmdString.begin(), ::tolower);
 
-		if (F::Commands.Run(sCommand, vArgs))
-			return;
+		std::deque<std::string> vArgs;
+		boost::split(vArgs, sCmdString, split_q());
+
+		if (!vArgs.empty())
+		{
+			std::string sCommand = vArgs.front();
+			vArgs.pop_front();
+
+			if (F::Commands.Run(sCommand, vArgs))
+				return;
+		}
 	}
 
 	CALL_ORIGINAL(rcx, szCmdString);

--- a/Amalgam/src/Hooks/VGuiMenuBuilder_AddMenuItem.cpp
+++ b/Amalgam/src/Hooks/VGuiMenuBuilder_AddMenuItem.cpp
@@ -31,7 +31,7 @@ MAKE_HOOK(VGuiMenuBuilder_AddMenuItem, S::VGuiMenuBuilder_AddMenuItem(), void*,
     static const auto dwDesired = S::CTFClientScoreBoardDialog_OnScoreBoardMouseRightRelease_AddMenuItem_Call();
     const auto dwRetAddr = uintptr_t(_ReturnAddress());
 
-    if (Vars::Visuals::UI::ScoreboardUtility.Value && dwRetAddr == dwDesired && PlayerIndex != -1)
+    if (Vars::Visuals::UI::ScoreboardUtility.Value && dwRetAddr == dwDesired && PlayerIndex != -1 && !G::Unload)
     {
         auto ret = CALL_ORIGINAL(rcx, pszButtonText, pszCommand, pszCategoryName);
 
@@ -59,7 +59,7 @@ MAKE_HOOK(VGuiMenuBuilder_AddMenuItem, S::VGuiMenuBuilder_AddMenuItem(), void*,
 MAKE_HOOK(CTFClientScoreBoardDialog_OnCommand, S::CTFClientScoreBoardDialog_OnCommand(), void,
     void* rcx, const char* command)
 {
-    if (!Vars::Visuals::UI::ScoreboardUtility.Value)
+    if (G::Unload || !Vars::Visuals::UI::ScoreboardUtility.Value)
         return CALL_ORIGINAL(rcx, command);
 
     auto uHash = FNV1A::Hash32(command);

--- a/Amalgam/src/SDK/Definitions/Interfaces.h
+++ b/Amalgam/src/SDK/Definitions/Interfaces.h
@@ -39,7 +39,7 @@ MAKE_INTERFACE_SIGNATURE_SEARCH(IDirect3DDevice9, DirectXDevice, "shaderapi", "4
 class CNullInterfaces
 {
 public:
-	void Initialize();
+	bool Initialize();
 };
 
 ADD_FEATURE_CUSTOM(CNullInterfaces, Interfaces, H);

--- a/Amalgam/src/SDK/Definitions/NullInterfaces.cpp
+++ b/Amalgam/src/SDK/Definitions/NullInterfaces.cpp
@@ -2,13 +2,15 @@
 
 #include "../../Utils/Assert/Assert.h"
 
-#define Validate(x) AssertCustom(x, std::format("H::Interfaces.Initialize() Failed to initialize {}", #x).c_str())
+#define Validate(x) AssertCustom(x, std::format("H::Interfaces.Initialize() Failed to initialize {}", #x).c_str()) bFail = !x;
 
 MAKE_SIGNATURE(Get_TFPartyClient, "client.dll", "48 8B 05 ? ? ? ? C3 CC CC CC CC CC CC CC CC 48 89 5C 24 ? 48 89 74 24 ? 48 89 7C 24 ? 41 56", 0x0);
 MAKE_SIGNATURE(Get_SteamNetworkingUtils, "client.dll", "40 53 48 83 EC ? 48 8B D9 48 8D 15 ? ? ? ? 33 C9 FF 15 ? ? ? ? 33 C9", 0x0);
 
-void CNullInterfaces::Initialize()
+bool CNullInterfaces::Initialize()
 {
+	bool bFail{false};
+
 	I::TFPartyClient = S::Get_TFPartyClient.Call<CTFPartyClient*>();
 	Validate(I::TFPartyClient);
 
@@ -35,4 +37,6 @@ void CNullInterfaces::Initialize()
 
 	S::Get_SteamNetworkingUtils.Call<ISteamNetworkingUtils*>(&I::SteamNetworkingUtils);
 	Validate(I::SteamNetworkingUtils);
+
+	return !bFail;
 }

--- a/Amalgam/src/SDK/Events/Events.cpp
+++ b/Amalgam/src/SDK/Events/Events.cpp
@@ -9,19 +9,24 @@
 #include "../../Features/Resolver/Resolver.h"
 #include "../../Features/Visuals/Visuals.h"
 
-void CEventListener::Initialize()
+bool CEventListener::Initialize()
 {
 	std::vector<const char*> vEvents = { 
 		"client_beginconnect", "client_connected", "client_disconnect", "game_newmap", "teamplay_round_start", "player_connect_client", "player_spawn", "player_changeclass", "player_hurt", "vote_cast", "item_pickup", "revive_player_notify"
 	};
 
+	bool bFail{false};
 	for (auto szEvent : vEvents)
 	{
 		I::GameEventManager->AddListener(this, szEvent, false);
 
 		if (!I::GameEventManager->FindListener(this, szEvent))
+		{
 			SDK::Output("Amalgam", std::format("Failed to add listener: {}", szEvent).c_str(), { 255, 150, 175, 255 });
+			bFail = true;
+		}
 	}
+	return !bFail;
 }
 
 void CEventListener::Unload()
@@ -31,7 +36,7 @@ void CEventListener::Unload()
 
 void CEventListener::FireGameEvent(IGameEvent* pEvent)
 {
-	if (!pEvent)
+	if (!pEvent || G::Unload)
 		return;
 
 	auto pLocal = H::Entities.GetLocal();

--- a/Amalgam/src/SDK/Events/Events.h
+++ b/Amalgam/src/SDK/Events/Events.h
@@ -5,7 +5,7 @@
 class CEventListener : public CGameEventListener
 {
 public:
-	void Initialize();
+	bool Initialize();
 	void Unload();
 
 	virtual void FireGameEvent(IGameEvent* pEvent) override;

--- a/Amalgam/src/Utils/CrashLog/CrashLog.cpp
+++ b/Amalgam/src/Utils/CrashLog/CrashLog.cpp
@@ -155,7 +155,13 @@ static LONG APIENTRY ExceptionFilter(PEXCEPTION_POINTERS ExceptionInfo)
 	return EXCEPTION_EXECUTE_HANDLER;
 }
 
+static PVOID handle;
 void CrashLog::Setup()
 {
-	AddVectoredExceptionHandler(1, ExceptionFilter);
+	handle = AddVectoredExceptionHandler(1, ExceptionFilter);
+}
+
+void CrashLog::Unload( )
+{
+	RemoveVectoredExceptionHandler( handle );
 }

--- a/Amalgam/src/Utils/CrashLog/CrashLog.h
+++ b/Amalgam/src/Utils/CrashLog/CrashLog.h
@@ -4,4 +4,5 @@
 namespace CrashLog
 {
 	void Setup();
+	void Unload();
 }

--- a/Amalgam/src/Utils/Hooks/Hooks.h
+++ b/Amalgam/src/Utils/Hooks/Hooks.h
@@ -35,13 +35,13 @@ public:
 {\
 	namespace name\
 	{\
-		void Init(); \
+		bool Init(); \
 		inline CHook Hook(#name, Init); \
 		using FN = type(__fastcall*)(__VA_ARGS__); \
 		type __fastcall Func(__VA_ARGS__); \
 	}\
 } \
-void Hooks::name::Init() { Hook.Create(reinterpret_cast<void*>(address), Func); } \
+bool Hooks::name::Init() { if (address) {Hook.Create(reinterpret_cast<void*>(address), Func); return true;} else { SDK::Output("Amalgam", std::format("Failed to initialize hook: {}", #name).c_str(), { 255, 150, 175, 255 }); return false;}} \
 type __fastcall Hooks::name::Func(__VA_ARGS__)
 
 class CHooks
@@ -50,7 +50,7 @@ public:
 	std::unordered_map<std::string, CHook*> m_mHooks = {};
 
 public:
-	void Initialize();
+	bool Initialize();
 	void Unload();
 };
 

--- a/Amalgam/src/Utils/Interfaces/Interfaces.cpp
+++ b/Amalgam/src/Utils/Interfaces/Interfaces.cpp
@@ -71,8 +71,9 @@ InterfaceInit_t::InterfaceInit_t(void** pPtr, const char* sDLLName, const char* 
 	U::Interfaces.AddInterface(this);
 }
 
-void CInterfaces::Initialize()
+bool CInterfaces::Initialize()
 {
+	bool bFail{false};
 	for (auto& Interface : m_vecInterfaces)
 	{
 		if (!Interface->m_pPtr || !Interface->m_pszDLLName || !Interface->m_pszVersion)
@@ -89,6 +90,7 @@ void CInterfaces::Initialize()
 			if (!dwDest)
 			{
 				AssertCustom(dwDest, std::format("CInterfaces::Initialize() failed to find signature:\n  {}\n  {}", Interface->m_pszDLLName, Interface->m_pszVersion).c_str());
+				bFail = true;
 				continue;
 			}
 
@@ -102,8 +104,9 @@ void CInterfaces::Initialize()
 			}
 		}
 
+		bFail = (bFail || !*Interface->m_pPtr);
 		AssertCustom(*Interface->m_pPtr, std::format("CInterfaces::Initialize() failed to initialize:\n  {}\n  {}", Interface->m_pszDLLName, Interface->m_pszVersion).c_str());
 	}
 
-	H::Interfaces.Initialize(); // Initialize any null interfaces
+	return !(bFail = (!H::Interfaces.Initialize() || bFail)); // Initialize any null interfaces
 }

--- a/Amalgam/src/Utils/Interfaces/Interfaces.h
+++ b/Amalgam/src/Utils/Interfaces/Interfaces.h
@@ -46,7 +46,7 @@ private:
 	std::vector<InterfaceInit_t*> m_vecInterfaces = {};
 
 public:
-	void Initialize();
+	bool Initialize();
 
 	inline void AddInterface(InterfaceInit_t* pInterface)
 	{

--- a/Amalgam/src/Utils/Signatures/Signatures.cpp
+++ b/Amalgam/src/Utils/Signatures/Signatures.cpp
@@ -14,22 +14,27 @@ CSignature::CSignature(const char* sDLLName, const char* sSignature, int nOffset
 	U::Signatures.AddSignature(this);
 }
 
-void CSignature::Initialize()
+bool CSignature::Initialize()
 {
 	m_dwVal = U::Memory.FindSignature(m_pszDLLName, m_pszSignature);
-	if (!m_dwVal)
+	if (!m_dwVal) {
 		OutputDebugStringA(std::format("CSignature::Initialize() failed to initialize:\n  {}\n  {}\n  {}\n", m_pszName, m_pszDLLName, m_pszSignature).c_str());
+		return false;
+	}
 
-	m_dwVal += m_nOffset;
+	return m_dwVal += m_nOffset;
 }
 
-void CSignatures::Initialize()
+bool CSignatures::Initialize()
 {
+	bool bFail{false};
 	for (auto Signature : m_vecSignatures)
 	{
 		if (!Signature)
 			continue;
 
-		Signature->Initialize();
+		if(!Signature->Initialize())
+			bFail = true;
 	}
+	return !bFail;
 }

--- a/Amalgam/src/Utils/Signatures/Signatures.h
+++ b/Amalgam/src/Utils/Signatures/Signatures.h
@@ -15,7 +15,7 @@ private:
 public:
 	CSignature(const char* sDLLName, const char* sSignature, int nOffset, const char* sName);
 
-	void Initialize();
+	bool Initialize();
 
 	inline uintptr_t operator()()
 	{
@@ -43,7 +43,7 @@ private:
 	std::vector<CSignature*> m_vecSignatures = {};
 
 public:
-	void Initialize();
+	bool Initialize();
 
 	inline void AddSignature(CSignature* pSignature)
 	{


### PR DESCRIPTION
Should no longer crash when reinjecting/uninjecting and joining a server (very useful for debugging)
Also fixed a bug in convar query removal that existed for years since it got first added to fedoraware (server kicks you out for not responding)